### PR TITLE
Add `Copy Error` button to the error dialog

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,7 @@ module.exports = options => {
 			if (isReady) {
 				const btnIndex = dialog.showMessageBox({
 					type: 'error',
-					buttons: [os.type === 'Darwin' ? 'Copy Error' : 'Copy error', 'OK'],
+					buttons: [process.platform === 'darwin' ? 'Copy Error' : 'Copy error', 'OK'],
 					defaultId: 1,
 					title,
 					noLink: true,

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const electron = require('electron');
-const os = require('os');
 const cleanStack = require('clean-stack');
 const extractStack = require('extract-stack');
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 'use strict';
 const electron = require('electron');
+const os = require('os');
 const cleanStack = require('clean-stack');
+const extractStack = require('extract-stack');
 
 const clipboard = electron.clipboard || electron.remote.clipboard;
 
@@ -33,18 +35,18 @@ module.exports = options => {
 			const stack = err ? (err.stack || err.message || err || '[No error message]') : '[Undefined error]';
 
 			if (isReady) {
-				dialog.showMessageBox({
+				const btnIndex = dialog.showMessageBox({
 					type: 'error',
-					buttons: ['Copy to clipboard', 'Ok'],
+					buttons: [os.type === 'Darwin' ? 'Copy Error' : 'Copy error', 'OK'],
 					defaultId: 1,
 					title,
 					noLink: true,
-					message: cleanStack(stack)
-				}, btnIndex => {
-					if (btnIndex === 0) {
-						clipboard.writeText(cleanStack(stack));
-					}
+					message: err.message,
+					detail: extractStack(err)
 				});
+				if (btnIndex === 0) {
+					clipboard.writeText(cleanStack(stack));
+				}
 			} else {
 				dialog.showErrorBox(title, cleanStack(stack));
 			}

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ module.exports = options => {
 
 		if (options.showDialog) {
 			const stack = err ? (err.stack || err.message || err || '[No error message]') : '[Undefined error]';
+			const message = err ? (err.message || err || '[No error message]') : '[Undefined error]';
 
 			if (isReady) {
 				const btnIndex = dialog.showMessageBox({
@@ -39,8 +40,8 @@ module.exports = options => {
 					buttons: [process.platform === 'darwin' ? 'Copy Error' : 'Copy error', 'OK'],
 					defaultId: 1,
 					title,
+					message,
 					noLink: true,
-					message: err.message,
 					detail: extractStack(err)
 				});
 				if (btnIndex === 0) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-unhandled",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Catch unhandled errors and promise rejections in your Electron app",
   "license": "MIT",
   "repository": "sindresorhus/electron-unhandled",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electron-unhandled",
-  "version": "0.1.2",
+  "version": "0.1.1",
   "description": "Catch unhandled errors and promise rejections in your Electron app",
   "license": "MIT",
   "repository": "sindresorhus/electron-unhandled",
@@ -32,7 +32,8 @@
     "debugging"
   ],
   "dependencies": {
-    "clean-stack": "^1.2.0"
+    "clean-stack": "^1.2.0",
+    "extract-stack": "^1.0.0"
   },
   "devDependencies": {
     "ava": "*",


### PR DESCRIPTION
Show a messageBox with a "copy to clipboard" button
If app is not ready, fall back to errorBox

I've also set "noLink" to true to prevent Windows from parsing "common" buttons and render them differently