### PR TITLE
Handle Bluebird unhandledrejection

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = options => {
 		}, 200);
 		window.addEventListener('unhandledrejection', event => {
 			event.preventDefault();
-			rejectionHandler(event.reason);
+			rejectionHandler(event.reason || event.detail.reason);
 		});
 	} else {
 		process.on('uncaughtException', err => {


### PR DESCRIPTION
Bluebird.js promises don't have event.reason, they instead have event.detail.reason. An unhanded rejection from bb causes an exception from your plugin. Given Bluebird's popularity it's probably worthwhile handing this case at least until they fix their side. As you can see they've taken a couple of kicks at this already. Links to their issues:
https://github.com/petkaantonov/bluebird/issues/1447
https://github.com/petkaantonov/bluebird/issues/1509