### PR TITLE
Fix Electron 6 compatibility

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,9 @@ const dialog = electron.dialog || electron.remote.dialog;
 const clipboard = electron.clipboard || electron.remote.clipboard;
 const appName = app.getName();
 
+// The dialog.showMessageBox method has been split into a sync and an async variant in Electron 6.0.0
+const showMessageBox = dialog.showMessageBoxSync || dialog.showMessageBox;
+
 let installed = false;
 
 let options = {
@@ -41,7 +44,7 @@ const handleError = (title, error) => {
 			}
 
 			// Intentionally not using the `title` option as it's not shown on macOS
-			const buttonIndex = dialog.showMessageBox({
+			const buttonIndex = showMessageBox({
 				type: 'error',
 				buttons,
 				defaultId: 0,


### PR DESCRIPTION
The `dialog.showMessageBox` method has been split into `dialog.showMessageBox` and `dialog.showMessageBoxSync` in Electron 6.0.0. This PR ensures that the sync variant is used in Electron >=6 without breaking compatibility with Electron <6.

I have no idea how to add tests for a change like this though, help is very much welcome.