### PR TITLE
Silence deprecation warning in Electron 7

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ const isDev = require('electron-is-dev');
 const app = electron.app || electron.remote.app;
 const dialog = electron.dialog || electron.remote.dialog;
 const clipboard = electron.clipboard || electron.remote.clipboard;
-const appName = app.getName();
+const appName = 'name' in app ? app.name : app.getName();
 
 // The dialog.showMessageBox method has been split into a sync and an async variant in Electron 6.0.0
 const showMessageBox = dialog.showMessageBoxSync || dialog.showMessageBox;


### PR DESCRIPTION
Running the current code on Electron 7 issues the following warning:
    'getName function' is deprecated and will be removed. Please use 'name property' instead.

Unfortunately, the `name` property is first documented for Electron 7 too. So to maintain compatibility,
we detect it's presence and use it only if available.