### PR TITLE
Avoid reporting null NonError

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,7 +84,7 @@ module.exports = inputOptions => {
 		}, 200);
 		window.addEventListener('error', event => {
 			event.preventDefault();
-			errorHandler(event.error);
+			errorHandler(event.error || event);
 		});
 
 		const rejectionHandler = debounce(reason => {


### PR DESCRIPTION
I got a few errors that were reported with NonError and a null message
It can happen when the error property is not set on the error intercepted by the error handler
See this fiddle and screenshot as an example: http://jsfiddle.net/p64rdm2g/1/

<img width="565" alt="Screen Shot 2020-01-06 at 9 34 59 AM" src="https://user-images.githubusercontent.com/521091/71806277-acad6c00-3068-11ea-9659-e2505e36208d.png">
