### PR TITLE
Fix error serialization

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
 		"clean-stack": "^2.1.0",
 		"electron-is-dev": "^2.0.0",
 		"ensure-error": "^2.0.0",
-		"lodash.debounce": "^4.0.8"
+		"lodash.debounce": "^4.0.8",
+		"serialize-error": "^9.1.0"
 	},
 	"devDependencies": {
 		"ava": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
 		"electron-is-dev": "^2.0.0",
 		"ensure-error": "^2.0.0",
 		"lodash.debounce": "^4.0.8",
-		"serialize-error": "^9.1.0"
+		"serialize-error": "^8.1.0"
 	},
 	"devDependencies": {
 		"ava": "^2.2.0",


### PR DESCRIPTION
- Change error serialize logic
- Drop usage of v8's serialize method
- Start using 'serialize-error' library to serialize errors

Fixes #26